### PR TITLE
feat: add string concatenation example

### DIFF
--- a/examples/concatenation.pt
+++ b/examples/concatenation.pt
@@ -1,0 +1,19 @@
+// Concaténation de chaînes — parce que coller des mots c'est un art.
+
+genre prenom = "Jean-Michel";
+genre nom = "Chaos";
+genre espace = " ";
+
+// Concaténation simple
+genre nom_complet = prenom + espace + nom;
+lache_un_com(nom_complet);
+
+// Concaténation directe
+lache_un_com("Salut " + prenom + " !");
+
+// Construction d'un message en plusieurs étapes
+genre debut = "Bienvenue dans ";
+genre milieu = "le monde de ";
+genre fin = "Peut-Être !";
+genre message = debut + milieu + fin;
+lache_un_com(message);


### PR DESCRIPTION
## Summary

- String concatenation via `+` already works end-to-end through `_pe_add()` in both C and TS runtimes
- Adds `examples/concatenation.pt` — demonstrates simple concat, chained concat, and variable interpolation via concat
- Test suite now covers 35 tests (up from 30)

## Test plan

- [x] `./peut-etre --no-chaos examples/concatenation.pt` runs correctly
- [x] `make test` — 35/35 tests pass (lex, parse, emit C, emit TS, end-to-end)

Closes #5